### PR TITLE
Fix Newton GBP builds

### DIFF
--- a/group-based-policy/rpm/openstack-neutron-gbp.spec.in
+++ b/group-based-policy/rpm/openstack-neutron-gbp.spec.in
@@ -50,12 +50,13 @@ gbp-db-manage --config-file /etc/neutron/neutron.conf upgrade head
 %{python2_sitelib}/gbpservice
 %{python2_sitelib}/group_based_policy*.egg-info
 %{_sysconfdir}/group-based-policy/policy.d/policy.json
-%{_sysconfdir}/servicechain/plugins/msc/*.ini
-%{_sysconfdir}/group-based-policy/drivers/*.ini
 %{_sysconfdir}/group-based-policy/*.ini
 %{_sysconfdir}/nfp.ini
 
 %changelog
+* Wed Jul 12 2017 Thomas Bachman <bachman@noironetworks.com> - 5.0.0-2
+- Remove service chain packaging for Newton
+
 * Fri Mar 10 2017 Amit Bose <bose@noironetworks.com> - 5.0.0-1
 - Update to Newton
 


### PR DESCRIPTION
The service chain functionality was removed from the
stable/newton GBP repo in this change ID:

  I03383145eaa72681695e12649f731ba1a6b8bad8

The RPM packaging scripts need to be updated to account
for the removal of the initialization scripts for the
service chain drivers.