### PR TITLE
Fix db-manage for RPM packaging

### DIFF
--- a/group-based-policy/rpm/openstack-neutron-gbp.spec.in
+++ b/group-based-policy/rpm/openstack-neutron-gbp.spec.in
@@ -38,7 +38,7 @@ rm -rf %{buildroot}%{python2_sitelib}/gbpservice/neutron/tests
 rm -rf %{buildroot}%{python2_sitelib}/gbpservice/tests
 
 %post
-gbp-db-manage --config-file /etc/neutron/neutron.conf upgrade head
+gbp-db-manage --config-file /etc/neutron/neutron.conf upgrade head || true
 
 %files
 %doc LICENSE


### PR DESCRIPTION
The existence of the SQL server isn't guaranteed when this package
is installed, so db-manage scripts should pipe to true in order to
prevent installer failures.