### PR TITLE
add gbp-validate executable to RPM

### DIFF
--- a/group-based-policy/rpm/openstack-neutron-gbp.spec.in
+++ b/group-based-policy/rpm/openstack-neutron-gbp.spec.in
@@ -47,6 +47,7 @@ gbp-db-manage --config-file /etc/neutron/neutron.conf upgrade head || true
 %{_bindir}/nfp
 %{_bindir}/nfp_proxy
 %{_bindir}/gbp-db-manage
+%{_bindir}/gbp-validate
 %{python2_sitelib}/gbpservice
 %{python2_sitelib}/group_based_policy*.egg-info
 %{_sysconfdir}/group-based-policy/policy.d/policy.json
@@ -55,6 +56,9 @@ gbp-db-manage --config-file /etc/neutron/neutron.conf upgrade head || true
 %{_sysconfdir}/nfp.ini
 
 %changelog
+* Thu May 24 2018 Robert Kukura <kukura@noironetworks.com> - 6.0.0-2
+- Add gbp-validate executable
+
 * Tue Sep 12 2017 Thomas Bachman <bachman@noironetworks.com> - 6.0.0-1
 - Update to Ocata
 


### PR DESCRIPTION
This is needed for testing gbp-validate, and also to fix the build process, which is currently failing to build the RPM because of this new executable.